### PR TITLE
DismissTriggerUsable Default value

### DIFF
--- a/Dismissable-Demo/ViewController.swift
+++ b/Dismissable-Demo/ViewController.swift
@@ -11,8 +11,13 @@ import Dismissable
 
 class ViewController: UIViewController, DismissTriggerUsable {
     
-    var dismissInteractor: DismissInteractor = DismissInteractor()
-    var dismissAnimator: DismissAnimator = DismissAnimator()
+//    // Custom Animator
+//    var dismissAnimator: DismissAnimator = {
+//        let animator = DismissAnimator()
+//        animator.dimmedViewStartColor = UIColor.blue.withAlphaComponent(0.4)
+//        animator.dimmedViewEndColor = UIColor.blue.withAlphaComponent(0)
+//        return animator
+//    }()
     
     @IBOutlet weak var tableView: UITableView!
     

--- a/Dismissable/DismissAnimator.swift
+++ b/Dismissable/DismissAnimator.swift
@@ -14,6 +14,10 @@ open class DismissAnimator : NSObject {
     public var dimmedViewEndColor: UIColor = UIColor.black.withAlphaComponent(0)
 }
 
+extension DismissAnimator {
+    static var `default`: DismissAnimator = DismissAnimator()
+}
+
 extension DismissAnimator : UIViewControllerAnimatedTransitioning {
     public func transitionDuration(using transitionContext: UIViewControllerContextTransitioning?) -> TimeInterval {
         return transitionDuration

--- a/Dismissable/DismissInteractor.swift
+++ b/Dismissable/DismissInteractor.swift
@@ -12,3 +12,7 @@ open class DismissInteractor: UIPercentDrivenInteractiveTransition {
     var hasStarted = false
     var shouldFinish = false
 }
+
+extension DismissInteractor {
+    static var `default`: DismissInteractor = DismissInteractor()
+}

--- a/Dismissable/DismissTriggerUsable.swift
+++ b/Dismissable/DismissTriggerUsable.swift
@@ -15,6 +15,11 @@ public protocol DismissTriggerUsable {
     var dismissAnimator: DismissAnimator { get }
 }
 
+public extension DismissTriggerUsable {
+    var dismissInteractor: DismissInteractor { return DismissInteractor.default }
+    var dismissAnimator: DismissAnimator { return DismissAnimator.default }
+}
+
 final class DismissTriggerTransitioningDelegate: NSObject, UIViewControllerTransitioningDelegate {
     
     private weak var rootViewController: DismissTriggerViewController?


### PR DESCRIPTION
DismissTriggerUsable Protocol Default Value 설정

DismissTriggerUsable.dismissInteractor,
DismissTriggerUsable.dismissAnimator 값이
getter 이기 때문에
internal 로 사용할 수 있게 싱글톤 객체를 생성해서 default 값 지정

Custom Animator 가 필요한 경우 
직접 생성해서 처리하면 됨

```swift
class ViewController: UIViewController, DismissTriggerUsable {

 // Custom Animator
var dismissAnimator: DismissAnimator = {
    let animator = DismissAnimator()
    animator.dimmedViewStartColor = UIColor.blue.withAlphaComponent(0.4)
    animator.dimmedViewEndColor = UIColor.blue.withAlphaComponent(0)
    return animator
}()

}
```